### PR TITLE
Fix: 'has_key' has been removed from Python 3, use 'in' instead

### DIFF
--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -964,7 +964,7 @@ class Shotgun(object):
         if order:
             sort_list = []
             for sort in order:
-                if sort.has_key('column'):
+                if 'column' in sort:
                     # TODO: warn about deprecation of 'column' param name
                     sort['field_name'] = sort['column']
                 sort.setdefault("direction", "asc")


### PR DESCRIPTION
Specifying an `order` for `find()` was broken in Python 3. This fixes it.