### PR TITLE
Fix: update used TLS protocol to TLSv1.2

### DIFF
--- a/shotgun_api3/lib/httplib2/__init__.py
+++ b/shotgun_api3/lib/httplib2/__init__.py
@@ -73,7 +73,7 @@ try:
             cert_reqs = ssl.CERT_NONE
         else:
             cert_reqs = ssl.CERT_REQUIRED
-        # We should be specifying SSL version 3 or TLS v1, but the ssl module
+        # We should be specifying SSL version 3 or TLS v1.2, but the ssl module
         # doesn't expose the necessary knobs. So we need to go with the default
         # of SSLv23.
         return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,

--- a/shotgun_api3/lib/httplib3/__init__.py
+++ b/shotgun_api3/lib/httplib3/__init__.py
@@ -833,7 +833,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
         if (cert_file or ca_certs) and not disable_ssl_certificate_validation:
             if not hasattr(ssl, 'SSLContext'):
                 raise CertificateValidationUnsupportedInPython31()
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
             context.verify_mode = ssl.CERT_REQUIRED
             if cert_file:
                 context.load_cert_chain(cert_file, key_file)


### PR DESCRIPTION
For communication with Shotgun TLSv1.2 should be used. Older versions will be deprecated.